### PR TITLE
Provide an option for title override in edit link generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Here is a full list of available arguments:
 | `devNote` | *null* | Display information to content editors. You may use plain text or HTML markup |
 | `entry` | *null* | Pass in an entry object to add an edit link for that entry |
 | `showEditInfo` | *true* | If set to `true`, the Edit Link will display the last updated date and the name of the author that last saved the entry |
+| `title` | *null* | If provided, overrides the entry's title or custom url used for the edit link's title |
 | `url` | *''* | A URL that will be navigated to when the "Edit" link is clicked |
 | `useCss` | *true* | Add the default styles to Edit Links or leave them off and style it your way |
 | `useJs` | *true* | Add the default Javascript used by Entry Edit Links. Setting this to `false` embeds the Entry Edit Link through Twig, instead |

--- a/src/services/EditLinks.php
+++ b/src/services/EditLinks.php
@@ -77,6 +77,15 @@ class EditLinks extends Component
             $config['revisionNote'] = null;
         }
 
+        // set title based on override, entry, or url provided
+        if (!isset($config['title'])) {
+            if ($config['type'] == 'entry') {
+                $config['title'] = $config['entry']->title;
+            } else {
+                $config['title'] = $config['url'];
+            }
+        }
+
         $oldMode = Craft::$app->view->getTemplateMode();
         Craft::$app->view->setTemplateMode(View::TEMPLATE_MODE_CP);
         $html = Craft::$app->view->renderTemplate('admin-bar/editLinks', $config);

--- a/src/templates/editLinks.twig
+++ b/src/templates/editLinks.twig
@@ -2,7 +2,6 @@
 {% set devNote = devNote ?? '' %}
 {% set id = id ?? 0 %}
 {% set localesEnabled = localesEnabled ?? false %}
-{% set title = entry.title ?? url %}
 {% set showEditInfo = showEditInfo ?? true %}
 {% set useCss = useCss ?? true %}
 {% set useJs = useJs ?? true %}
@@ -44,7 +43,7 @@
                     <div class="editlink__photo">{% if displayEditAuthor and currentUser.photo ?? false %}<img src="{{ currentUser.getThumbUrl(50) }}" alt="{{ currentUser.friendlyName }}’s photo"/>{% endif %}</div>
                     <div class="editlink__name">{% if displayEditAuthor %}{{ revisionAuthor.friendlyName ?? entry.author.friendlyName }}{% endif %}</div>
                 {% else %}
-                    <div class="editlink__updated_label">{{ url }}</div>
+                    <div class="editlink__updated_label">{{ title }}</div>
                 {% endif %}
             {% endif %}
         </div>


### PR DESCRIPTION
This adds an additional `title` parameter to editLink generation that will override the title meta information on an edit link, and in the case of a user-provided URL, will override the label that appears on the side.

To facilitate this I've moved setting the title parameter from the Twig template into the controller.