### PR TITLE
Fixed order of some null coalescing operations to avoid raising notices.

### DIFF
--- a/src/services/Bar.php
+++ b/src/services/Bar.php
@@ -84,8 +84,8 @@ class Bar extends Component
 
                     if (
                         $enabled &&
-                        $widget['handle'] ?? false &&
-                        $widget['template'] ?? false
+                        ($widget['handle'] ?? false) &&
+                        ($widget['template'] ?? false)
                     ) {
                         $widgets[] = [
                             'id' => $plugin->handle . '_' . $widget['handle'],
@@ -115,7 +115,7 @@ class Bar extends Component
         foreach($widgetsFromPlugins as $pluginWidget) {
             $id = $pluginWidget['pluginHandle'] . '_' . $pluginWidget['handle'];
             $enabled = $pluginWidget['enabled'] ?? true;
-            if ($enabled && $settings['widgets'][$id] ?? false && $settings['widgets'][$id] === 1) {
+            if ($enabled && ($settings['widgets'][$id] ?? false) && $settings['widgets'][$id] === 1) {
                 $widgets[] = $pluginWidget;
             }
         }


### PR DESCRIPTION
On a fresh install of admin bar, noticed it was raising a notification in dev mode.

For example on line 118 of `src/services/Bar.php` there is an `if` statement making use of the `??` operator, which is of lower precedence than the `&&` operator before it, causing a notice to be thrown as it is evaluated in this order:

```
($enabled && $settings['widgets'][$id]) ?? false ...
```

This pull request wraps a few of these operators in parentheses to ensure notices aren't thrown from unexpected evaluation of missing keys from arrays.