### PR TITLE
Fix edit links for Craft 3.1

### DIFF
--- a/src/templates/bar.twig
+++ b/src/templates/bar.twig
@@ -79,14 +79,14 @@
                         <a href="{{ url(craft.app.config.general.cpTrigger ~ '/dashboard') }}" class="adminbar__has_icon"><span class="adminbar__icon">{{ svg(dashboardPath) }}</span>{{ 'Dashboard'|t }}</a>
                     {% endif %}
 
-                    {% if entry ?? false and (currentUser ? currentUser.can('editEntries:[' ~ entry.section.id ~ ']') : true) %}
+                    {% if entry ?? false and (entry.section.id in craft.app.sections.editableSectionIds) %}
                         {% set sectionName = displayDefaultEditSection ? ' ' ~ entry.section : ''  %}
                         {% set entryEditUrl = entry.cpEditUrl %}
 
                         <a href="{{ url(entryEditUrl) }}" class="adminbar__has_icon"><span class="adminbar__icon">{{ svg(editPath) }}</span>{{ 'Edit'|t ~ sectionName }}</a>
                     {% endif %}
 
-                    {% if category ?? false and (currentUser ? currentUser.can('editCategories:[' ~ category.group.id ~ ']') : true) %}
+                    {% if category ?? false and (category.group.id in craft.app.categories.editableGroupIds) %}
                         {% set sectionName = displayDefaultEditSection ? ' ' ~ category : ''  %}
                         {% set categoryEditUrl = category.cpEditUrl %}
 


### PR DESCRIPTION
In Craft 3.1+ the user permissions for sections/categories changed (they use uid instead of id, now). This change should work in Craft 3 onwards (including in Craft 3.1+) since it uses the public API instead of relying on Craft implementation details.